### PR TITLE
Rename "GoogleSignInButton" to "GithubSignInButton"

### DIFF
--- a/components/forms/user-auth-form.tsx
+++ b/components/forms/user-auth-form.tsx
@@ -15,7 +15,7 @@ import { useSearchParams } from 'next/navigation';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import * as z from 'zod';
-import GoogleSignInButton from '../github-auth-button';
+import GithubSignInButton from '../github-auth-button';
 
 const formSchema = z.object({
   email: z.string().email({ message: 'Enter a valid email address' })
@@ -83,7 +83,7 @@ export default function UserAuthForm() {
           </span>
         </div>
       </div>
-      <GoogleSignInButton />
+      <GithubSignInButton />
     </>
   );
 }

--- a/components/github-auth-button.tsx
+++ b/components/github-auth-button.tsx
@@ -5,7 +5,7 @@ import { signIn } from 'next-auth/react';
 import { Button } from './ui/button';
 import { Icons } from './icons';
 
-export default function GoogleSignInButton() {
+export default function GithubSignInButton() {
   const searchParams = useSearchParams();
   const callbackUrl = searchParams.get('callbackUrl');
 


### PR DESCRIPTION
Fix the github-auth-button file wrongly using "GoogleSignInButton" as the display name by replacing it with "GithubSignInButton".