### PR TITLE
fix: input type validation

### DIFF
--- a/app/dashboard/product/_components/product-form.tsx
+++ b/app/dashboard/product/_components/product-form.tsx
@@ -49,7 +49,7 @@ const formSchema = z.object({
     message: 'Product name must be at least 2 characters.'
   }),
   category: z.string(),
-  price: z.number(),
+  price: z.coerce.number(),
   description: z.string().min(10, {
     message: 'Description must be at least 10 characters.'
   })


### PR DESCRIPTION
The input field on the Create New Product page won’t accept number types because, for an input with type="number", e.target.value returns a string