### PR TITLE
fix: keep infobar state across breakpoints

### DIFF
--- a/src/components/layout/info-sidebar.tsx
+++ b/src/components/layout/info-sidebar.tsx
@@ -9,6 +9,7 @@ import {
   InfobarGroup,
   InfobarGroupContent,
   InfobarHeader,
+  InfobarRail,
   InfobarTrigger,
   useInfobar
 } from '@/components/ui/infobar';
@@ -92,6 +93,7 @@ export function InfoSidebar({ ...props }: React.ComponentProps<typeof Infobar>) 
           </InfobarGroupContent>
         </InfobarGroup>
       </InfobarContent>
+      <InfobarRail />
     </Infobar>
   );
 }

--- a/src/components/ui/infobar.tsx
+++ b/src/components/ui/infobar.tsx
@@ -110,13 +110,17 @@ function InfobarProvider({
 
   // Helper to toggle the infobar.
   const toggleInfobar = React.useCallback(() => {
-    return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open);
-  }, [isMobile, setOpen, setOpenMobile]);
+    setOpen((open) => !open);
+  }, [setOpen]);
 
-  // Close infobar when switching between mobile and desktop to prevent state desync
+  // Preserve the current infobar state when switching between mobile and desktop.
   React.useEffect(() => {
-    setOpenMobile(false);
-    _setOpen(false);
+    if (isMobile) {
+      setOpenMobile(open);
+    } else {
+      setOpen(openMobile);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only reconcile when the breakpoint changes
   }, [isMobile]);
 
   // Adds a keyboard shortcut to toggle the infobar.
@@ -275,7 +279,7 @@ function Infobar({
 
   return (
     <div
-      className='group peer text-sidebar-foreground hidden md:block'
+      className='group peer text-sidebar-foreground relative hidden md:block'
       data-state={state}
       data-collapsible={state === 'collapsed' ? collapsible : ''}
       data-variant={variant}


### PR DESCRIPTION
## Summary
- preserve the current infobar open state when the layout crosses the mobile/desktop breakpoint instead of force-closing both stores
- route the shared toggle path through the same setter so the desktop sidebar state and mobile Sheet state stay in sync
- restore the infobar rail inside the content-area infobar so a collapsed desktop panel still has a visible reopen affordance

Related to #165.

## Tests
- `git diff --check`
- `bunx oxlint src/components/ui/infobar.tsx src/components/layout/info-sidebar.tsx`
- `bun run lint`
- `bun run build`
