### PR TITLE
docs: add Deploy to PandaStack button

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@
 </div>
 <br />
 <div align="center">
+  <a href="https://dashboard.pandastack.io/deploy?repo=Kiranism/next-shadcn-dashboard-starter&type=container"><img src="https://dashboard.pandastack.io/deploy-button.svg" alt="Deploy to PandaStack" height="36" /></a>
+</div>
+<br />
+<div align="center">
   <img src="/public/shadcn-dashboard.png" alt="Shadcn Dashboard Cover" style="max-width: 100%; border-radius: 8px;" />
 </div>
 


### PR DESCRIPTION
## What this does

Adds a **Deploy to PandaStack** button to the README, alongside the existing deploy options.

[PandaStack](https://pandastack.io) is a deployment platform (like Railway/Render). It auto-detects the framework and runs the app — one click, no config. This PR only adds a README badge; no code or workflow changes.

If you'd prefer not to include it, feel free to close — no worries either way. Thanks for the great project! 🙌