### PR TITLE
Fix sidebar menu item spacing

### DIFF
--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -437,7 +437,7 @@ function SidebarMenu({ className, ...props }: React.ComponentProps<'ul'>) {
     <ul
       data-slot='sidebar-menu'
       data-sidebar='menu'
-      className={cn('flex w-full min-w-0 flex-col gap-0', className)}
+      className={cn('flex w-full min-w-0 flex-col gap-1', className)}
       {...props}
     />
   );


### PR DESCRIPTION
Restores the gap-1 between sidebar menu items that the base-nova sidebar refresh replaced with gap-0, which made adjacent active/hover pills fuse together.